### PR TITLE
Removed join type 'outer join'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/deployment
+.classpath
+.project
+*.launch
+[Tt]humbs.db


### PR DESCRIPTION
Removed join type 'outer join', because that join type does not exist in Mendix