### PR TITLE
Fix for using the proper date format when exporting to Excel

### DIFF
--- a/javasource/xlsreport/actions/GenerateExcelDoc.java
+++ b/javasource/xlsreport/actions/GenerateExcelDoc.java
@@ -23,6 +23,7 @@ import xlsreport.proxies.MxCellStyle;
 import xlsreport.proxies.MxColumn;
 import xlsreport.proxies.MxData;
 import xlsreport.proxies.MxSheet;
+import xlsreport.proxies.MxXPath;
 import xlsreport.report.DataOQL;
 import xlsreport.report.data.ColumnPreset;
 import xlsreport.report.export.Export;
@@ -116,6 +117,16 @@ public class GenerateExcelDoc extends CustomJavaAction<IMendixObject>
 									styleGuid = defaultStyle;
 								}
 								ColumnPreset preset = new ColumnPreset(mxColumn.getName(), mxColumn.getNameAsHeader(), mxColumn.getColumnNumber(), mxColumn.getMxXPath_MxData(), styleGuid);
+								
+								//Check if it is a date column. If so indicate the column should use the date format
+								MxXPath xpath = mxColumn.getMxXPath_MxData();
+								if (xpath != null && xpath.getMxXPath_MxObjectMember() != null)	{
+									String attributeType = xpath.getMxXPath_MxObjectMember().getAttributeType();
+									if ("DateTime".equals(attributeType)) {
+										preset.setDateTimeFormat(true);
+									}
+								}
+								
 								if (mxColumn.getResultAggregate()) {
 									preset.addResultAggregation(mxColumn.getResultAggregateFunction());
 								}


### PR DESCRIPTION
This is a small fix to make sure that date time fields are displayed in Excel properly using the configured date format