### PR TITLE
Update DataOQL.java allow further Date contraints

### DIFF
--- a/javasource/xlsreport/report/DataOQL.java
+++ b/javasource/xlsreport/report/DataOQL.java
@@ -299,6 +299,12 @@ public class DataOQL
 					case SmallerEqual:
 						this.WHERE.append(" <= ").append(compare);
 						break;
+					case NotEmpty:
+						this.WHERE.append(" != NULL");
+						break;
+					case _empty:
+						this.WHERE.append(" = NULL");
+						break;
 					default:
 						break;
 				}


### PR DESCRIPTION
Added the ability to constrain by "empty" and "not is empty" selection, which before wasn’t available.