### PR TITLE
Update DataOQL.java

### DIFF
--- a/javasource/xlsreport/report/DataOQL.java
+++ b/javasource/xlsreport/report/DataOQL.java
@@ -33,7 +33,7 @@ import java.util.regex.Pattern;
 public class DataOQL
 {
 	private static ILogNode log = Core.getLogger("XLSreport");
-	static final Pattern PATTERN_RESERVED_OQL = Pattern.compile("\\b(select|distinct|as|avg|count|max|min|sum|from|inner|left|right|full|outer|join|on|where|and|or|group|by|limit|offset|order|asc|desc|having|cast|coalesce|like|in|exists|not|case|when|then|else|end|boolean|datetime|float|integer|long|string|null|year|month|day|hour|minute)\\b", Pattern.CASE_INSENSITIVE);
+	static final Pattern PATTERN_RESERVED_OQL = Pattern.compile("\\b(select|distinct|as|avg|count|max|min|sum|from|inner|left|right|full|outer|join|on|where|and|or|group|by|limit|offset|order|asc|desc|having|cast|coalesce|like|in|exists|not|case|when|then|else|end|boolean|datetime|float|integer|long|string|null|year|month|day|hour|minute|quarter|second|week|weekday|dayofyear)\\b", Pattern.CASE_INSENSITIVE);
 	private IContext context;
 	private MxObjectType inputObjectType;
 	


### PR DESCRIPTION
Updated PATTERN_RESERVED_OQL to include quarter|second|week|weekday|dayofyear to prevent errors like:

Caused by: com.mendix.systemwideinterfaces.MendixRuntimeException: OQL query cannot be parsed: SELECT adeea6005.Quarter AS Quarter0, adeea6005.Second AS Second0, adeea6005.DayOfYear AS DayOfYear0, adeea6005.Week AS Week0, adeea6005.WeekDay AS WeekDay0  FROM "MyFirstModule"."Entity" AS adeea6005    ;
Error on line 1 character 17: no viable alternative at input 'Quarter'
Error on line 1 character 48: no viable alternative at input 'Second'
Error on line 1 character 77: no viable alternative at input 'DayOfYear'
Error on line 1 character 112: no viable alternative at input 'Week'
Error on line 1 character 137: no viable alternative at input 'WeekDay'